### PR TITLE
Fix java release name, tag, and release notes

### DIFF
--- a/releasetool/commands/tag/java.py
+++ b/releasetool/commands/tag/java.py
@@ -86,7 +86,7 @@ def get_release_notes(ctx: Context) -> None:
     click.secho("> Grabbing the release notes.", fg="cyan")
 
     match = re.search(
-        r"This pull request was generated using releasetool\.\n\n(.*)",
+        r"This pull request was generated using releasetool\.\s+(.*)",
         ctx.release_pr["body"],
         re.DOTALL | re.MULTILINE,
     )
@@ -103,9 +103,9 @@ def create_release(ctx: Context) -> None:
 
     ctx.github_release = ctx.github.create_release(
         repository=ctx.upstream_repo,
-        tag_name=ctx.release_version,
+        tag_name=ctx.release_tag,
         target_committish=ctx.release_pr["merge_commit_sha"],
-        name=f"{ctx.release_version}",
+        name=ctx.release_tag,
         body=ctx.release_notes,
     )
 


### PR DESCRIPTION
The java release tag needed to be the vX.Y.Z version, not just X.Y.Z. The release names are also with the "v" prefix.