### PR TITLE
feat(nodejs): bump package version in samples/package.json as well

### DIFF
--- a/releasetool/commands/start/nodejs.py
+++ b/releasetool/commands/start/nodejs.py
@@ -51,7 +51,9 @@ class Context(releasetool.commands.common.GitHubContext):
 
 def determine_package_name(ctx: Context) -> None:
     click.secho("> Figuring out the package name.", fg="cyan")
-    ctx.package_name = os.path.basename(os.getcwd())
+    ctx.package_name = releasetool.filehelpers.extract(
+        "package.json", r'"name": "(.*?)"'
+    )
     click.secho(f"Looks like we're releasing {ctx.package_name}.")
 
 
@@ -137,7 +139,7 @@ def determine_release_version(ctx: Context) -> None:
 
 
 def create_release_branch(ctx) -> None:
-    ctx.release_branch = f"release-{ctx.package_name}-v{ctx.release_version}"
+    ctx.release_branch = f"release-v{ctx.release_version}"
     click.secho(f"> Creating branch {ctx.release_branch}", fg="cyan")
     return releasetool.git.checkout_create_branch(ctx.release_branch)
 
@@ -169,11 +171,28 @@ def update_package_json(ctx: Context) -> None:
     )
 
 
+def update_samples_package_json(ctx: Context) -> None:
+    click.secho("> Updating samples/package.json.", fg="cyan")
+    try:
+        releasetool.filehelpers.replace(
+            "samples/package.json",
+            f'"{ctx.package_name}": "(.+?)"',
+            f'"{ctx.package_name}": "^{ctx.release_version}"',
+        )
+    except FileNotFoundError:
+        pass
+
+
 def create_release_commit(ctx: Context) -> None:
     """Create a release commit."""
     click.secho("> Committing changes", fg="cyan")
     releasetool.git.commit(
-        ["CHANGELOG.md", "package.json"], f"Release v{ctx.release_version}"
+        [
+            "CHANGELOG.md",
+            "package.json",
+            "samples/package.json"
+        ],
+        f"Release v{ctx.release_version}",
     )
 
 
@@ -213,6 +232,7 @@ def start() -> None:
     create_release_branch(ctx)
     update_changelog(ctx)
     update_package_json(ctx)
+    update_samples_package_json(ctx)
     create_release_commit(ctx)
     push_release_branch(ctx)
     # TODO: Confirm?

--- a/releasetool/filehelpers.py
+++ b/releasetool/filehelpers.py
@@ -81,3 +81,11 @@ def replace(filename: str, expr: str, replacement: str) -> None:
         fh.seek(0)
         fh.write(content)
         fh.truncate()
+
+
+def extract(filename: str, expr: str) -> str:
+    with open(filename, 'r') as fh:
+        content = fh.read()
+
+        matches = re.search(expr, content)
+        return matches.group(1)


### PR DESCRIPTION
This also involve changing the displayed `package_name` to the actual NPM scoped-name.
`nodejs-vision` => `@google-cloud/nodejs-vision`

fixes #13 