### PR TITLE
Fix missing twine dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,8 @@ dependencies = [
     "attrs",
     "click",
     "keyring",
-    "packaging"
+    "packaging",
+    "twine",
 ]
 
 packages = setuptools.find_packages()


### PR DESCRIPTION
Twine is used in `releasetool/releasetool/commands/tag/python_tool.py` to publish to PyPI. https://github.com/GoogleCloudPlatform/synthtool/issues/30
    