### PR TITLE
Add link to Kokoro release job for python tools

### DIFF
--- a/releasetool/commands/tag/python_tool.py
+++ b/releasetool/commands/tag/python_tool.py
@@ -66,14 +66,12 @@ def publish_to_pypi(ctx: python.Context) -> None:
     project = f"prod:cloud-devrel/client-libraries/{ctx.package_name}/release"
     project_url = parse.urljoin(kokoro_url, parse.quote_plus(project))
 
-    commitish = ctx.release_pr["merge_commit_sha"]
-
     click.secho(
         f"> Trigger the Kokoro build with the commitish below to publish to PyPI.",
         fg="cyan",
     )
     click.secho(f"Build:\t\t{click.style(project_url, underline=True)}")
-    click.secho(f"Commitish:\t{click.style(commitish, bold=True)}")
+    click.secho(f"Commitish:\t{click.style(ctx.release_tag, bold=True)}")
 
     if click.confirm("Would you like to go the Kokoro build page?"):
         click.launch(project_url)


### PR DESCRIPTION
For python tools, provide the user with a link to the Kokoro release job.

```
> Trigger the Kokoro build with the commitish below to publish to PyPI.
Build:		https://fusion.corp.google.com/projectanalysis/current/KOKORO/prod%3Acloud-devrel%2Fclient-libraries%2Freleasetool%2Frelease
Commitish:	f0ca24dc9956eaed66623ee674efb6958b7856f3
Would you like to go the Kokoro build page? [y/N]: y
\o/ All done!
```